### PR TITLE
Remove useless run-ict and avoid filename error

### DIFF
--- a/install-ict_debian.sh
+++ b/install-ict_debian.sh
@@ -42,7 +42,7 @@ if [ "$1" = "BUILD" ]; then
 		git clone https://github.com/${GITREPO}
 	fi
 	cd ${ICTHOME}/${ICTDIR}/ict
-	rm ict.jar
+	rm *.jar
 	gradle fatJar
 	mv *.jar ict.jar
 fi
@@ -52,7 +52,7 @@ if [ "$1" = "RELEASE" ]; then
 	if [ ! -f ict/ict-${VERSION}.jar ]; then
 			mkdir ict
 			cd ict
-			rm ict.jar
+			rm *.jar
 			wget https://github.com/iotaledger/ict/releases/download/${VERSION}/ict-${VERSION}.jar
 			mv *.jar ict.jar
 	fi

--- a/install-ict_debian.sh
+++ b/install-ict_debian.sh
@@ -42,7 +42,9 @@ if [ "$1" = "BUILD" ]; then
 		git clone https://github.com/${GITREPO}
 	fi
 	cd ${ICTHOME}/${ICTDIR}/ict
+	rm ict.jar
 	gradle fatJar
+	mv *.jar ict.jar
 fi
 
 if [ "$1" = "RELEASE" ]; then
@@ -50,18 +52,11 @@ if [ "$1" = "RELEASE" ]; then
 	if [ ! -f ict/ict-${VERSION}.jar ]; then
 			mkdir ict
 			cd ict
+			rm ict.jar
 			wget https://github.com/iotaledger/ict/releases/download/${VERSION}/ict-${VERSION}.jar
+			mv *.jar ict.jar
 	fi
 fi
-
-
-cat <<EOF > ${ICTHOME}/run-ict.sh
-#!/bin/bash
-cd ${ICTHOME}/${ICTDIR}
-java -jar ict/ict-${VERSION}.jar -c ${ICTHOME}/config/ict.cfg
-EOF
-
-chmod a+x ${ICTHOME}/run-ict.sh
 
 mkdir -p ${ICTHOME}/config
 
@@ -92,7 +87,7 @@ cat <<EOF > /lib/systemd/system/ict.service
 Description=IOTA ICT
 After=network.target
 [Service]
-ExecStart=/bin/bash -u ${ICTHOME}/run-ict.sh
+ExecStart=/bin/java -jar ict/ict.jar -c ${ICTHOME}/config/ict.cfg
 WorkingDirectory=${ICTHOME}/${ICTDIR}
 StandardOutput=inherit
 StandardError=inherit


### PR DESCRIPTION
Run-ict.sh script is basically useless. Service can be modified to directly execute the built file.

Some versions are labeled as `SNAPSHOT`, the script does not take that into account so it is impossible to actually run the script. For instance, the built script is `ict-0.3-SNAPSHOT.jar` but the `run-ict.sh` tries to run `ict-0.2.3.jar`. I propose to remove the jar file, build or download last version and finally rename it to simply `ict.jar`.